### PR TITLE
Configure PWA name and icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#000000" />
   <link rel="apple-touch-icon" href="/imagens_inicial/logo_pizzaria.png" />
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="LA CARDAPIO">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Cardápio LA",
-  "name": "Cardápio LA",
+  "short_name": "LA CARDAPIO",
+  "name": "LA CARDAPIO",
   "icons": [
     {
       "src": "/imagens_inicial/logo_pizzaria.png",
@@ -14,7 +14,7 @@
     }
   ],
   "start_url": ".",
-  "display": "standalone",
+  "display": "fullscreen",
   "theme_color": "#000000",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
## Summary
- tweak PWA manifest to use `LA CARDAPIO` name
- enable full-screen mode
- add iOS specific meta tags so the app launches full-screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688518b60a608332968a8f98a178f5db