### PR TITLE
Ajusta logo e muda cor amarelo

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       background-color: #000000;
       padding: 8px 20px; /* Padding vertical reduzido */
       text-align: center;
-      color: #FFC107;
+      color: #FFA726;
       font-size: 1.2em; /* Fonte menor */
       font-weight: bold;
       position: relative;
@@ -109,7 +109,7 @@
       font-size: 1em; /* Fonte um pouco maior */
       height: 110px; /* Altura reduzida */
       border-radius: 15px;
-      background-color: #FFC107;
+      background-color: #FFA726;
       color: #2d2d2d;
       cursor: pointer;
       transition: all 0.3s;
@@ -124,7 +124,7 @@
       font-size: 1em;
       border: none;
       border-radius: 8px;
-      background-color: #FFC107;
+      background-color: #FFA726;
       color: #2d2d2d;
       cursor: pointer;
       transition: background 0.3s;
@@ -137,7 +137,7 @@
     }
 
     button:hover {
-      background-color: #ffee00;
+      background-color: #FFB74D;
     }
 
     /* Logo abaixo do botão "Informações" */
@@ -149,7 +149,10 @@
     #logoPequena {
       width: 120px;
       /* Ajuste conforme necessário */
-      margin-top: 10px;
+      margin: 20px auto 0 auto;
+      display: block;
+      grid-column: 1 / -1;
+      justify-self: center;
     }
 
     .tela {
@@ -319,7 +322,7 @@
     }
 
     .quantidade button {
-      background-color: #ffee00;
+      background-color: #FFB74D;
       margin: 0 10px;
       width: 40px;
     }
@@ -412,7 +415,7 @@
       font-size: 1.2em;
       font-weight: bold;
       text-align: right;
-      color: #FFC107;
+      color: #FFA726;
     }
 
     .botoes-pedidos {
@@ -593,7 +596,7 @@
     .btn-pedido {
       width: 100%;
       max-width: 300px;
-      background: #FFC107;
+      background: #FFA726;
       display: block;
       margin: 12px auto 0;
       padding: 15px 25px;
@@ -737,7 +740,7 @@
       gap: 8px;
     }
     .ingrediente-tag {
-      background-color: #FFC107;
+      background-color: #FFA726;
       color: #2d2d2d;
       padding: 5px 10px;
       border-radius: 15px;
@@ -869,7 +872,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -936,7 +939,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1003,7 +1006,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1070,7 +1073,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1137,7 +1140,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1204,7 +1207,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1271,7 +1274,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1338,7 +1341,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1405,7 +1408,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1472,7 +1475,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1539,7 +1542,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1606,7 +1609,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1673,7 +1676,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1740,7 +1743,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1807,7 +1810,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1874,7 +1877,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -1941,7 +1944,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -2008,7 +2011,7 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFC107;
+      background-color: #FFA726;
       border-color: #D90429;
       font-weight: bold;
     }
@@ -4106,7 +4109,7 @@
             </div>
             <div style="margin-left: 10px;">
               <button onclick="removerPedido(${index})"
-                style="background-color: #ffee00; color: #000; border: none; border-radius: 8px;
+                style="background-color: #FFB74D; color: #000; border: none; border-radius: 8px;
                        padding: 8px 10px; font-size: 1em; cursor: pointer;">
                 🗑️
               </button>


### PR DESCRIPTION
## Summary
- centralizar a logo no menu inicial e manter depois dos botões
- usar tom de amarelo mais puxado para laranja em todo o site

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68851a9b00808332965a0b84abca34a0