### PR TITLE
Enhance theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
     body {
       background-color: #000000;
-      color: #D90429;
+      color: #FF0000;
     }
 
     h1, h2, h3, h4, h5, h6 {
@@ -54,8 +54,8 @@
       background-color: #000000;
       padding: 8px 20px; /* Padding vertical reduzido */
       text-align: center;
-      color: #FFA726;
-      font-size: 1.2em; /* Fonte menor */
+      color: #FFD700;
+      font-size: 1.4em; /* Fonte menor */
       font-weight: bold;
       position: relative;
       z-index: 10;
@@ -110,7 +110,7 @@
       font-weight: bold; /* Melhora a visualização */
       height: 110px; /* Altura reduzida */
       border-radius: 15px;
-      background-color: #FFA726;
+      background-color: #FFD700;
       color: #2d2d2d;
       cursor: pointer;
       transition: all 0.3s;
@@ -125,7 +125,7 @@
       font-size: 1em;
       border: none;
       border-radius: 8px;
-      background-color: #FFA726;
+      background-color: #FFD700;
       color: #2d2d2d;
       cursor: pointer;
       transition: background 0.3s;
@@ -138,7 +138,7 @@
     }
 
     button:hover {
-      background-color: #FFB74D;
+      background-color: #FFEB3B;
     }
 
     /* Logo abaixo do botão "Informações" */
@@ -176,7 +176,7 @@
 
     .categorias button,
     .subcategorias button {
-      background-color: #D90429;
+      background-color: #FF0000;
       color: #fff;
       width: 100%;
       max-width: 320px; /* Largura máxima para consistência */
@@ -197,7 +197,7 @@
       width: 90%;
       padding: 10px;
       margin-bottom: 15px;
-      border: 2px solid #D90429;
+      border: 2px solid #FF0000;
       border-radius: 8px;
       font-size: 1em;
     }
@@ -234,14 +234,14 @@
     .produto-preco {
       flex-shrink: 0;
       background-color: transparent;
-      color: #D90429;
+      color: #FF0000;
       font-weight: bold;
       padding: 8px 12px;
       border-radius: 8px;
       font-size: 1.2em;
       text-align: center;
       min-width: 90px;
-      border: 2px solid #D90429;
+      border: 2px solid #FF0000;
     }
 
     .precos {
@@ -323,7 +323,7 @@
     }
 
     .quantidade button {
-      background-color: #FFB74D;
+      background-color: #FFEB3B;
       margin: 0 10px;
       width: 40px;
     }
@@ -355,7 +355,7 @@
 
     .total {
       font-size: 1.2em;
-      color: #D90429;
+      color: #FF0000;
       font-weight: bold;
       text-align: right;
       margin-bottom: 15px;
@@ -416,7 +416,7 @@
       font-size: 1.2em;
       font-weight: bold;
       text-align: right;
-      color: #FFA726;
+      color: #FFD700;
     }
 
     .botoes-pedidos {
@@ -504,7 +504,7 @@
       width: 100%;
       padding: 10px;
       margin-bottom: 15px;
-      border: 2px solid #D90429;
+      border: 2px solid #FF0000;
       border-radius: 8px;
       font-size: 1em;
     }
@@ -597,7 +597,7 @@
     .btn-pedido {
       width: 100%;
       max-width: 300px;
-      background: #FFA726;
+      background: #FFD700;
       display: block;
       margin: 12px auto 0;
       padding: 15px 25px;
@@ -741,7 +741,7 @@
       gap: 8px;
     }
     .ingrediente-tag {
-      background-color: #FFA726;
+      background-color: #FFD700;
       color: #2d2d2d;
       padding: 5px 10px;
       border-radius: 15px;
@@ -764,7 +764,7 @@
 
     #montePizza .produto.selecionado {
       background: #fff8b7;
-      border: 1px solid #D90429;
+      border: 1px solid #FF0000;
     }
 
     #listaIngredientesHamburguer {
@@ -873,8 +873,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -940,8 +940,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1007,8 +1007,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1074,8 +1074,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1141,8 +1141,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1208,8 +1208,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1275,8 +1275,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1342,8 +1342,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1409,8 +1409,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1476,8 +1476,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1543,8 +1543,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1610,8 +1610,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1677,8 +1677,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1744,8 +1744,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1811,8 +1811,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1878,8 +1878,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -1945,8 +1945,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -2012,8 +2012,8 @@
     }
 
     .lista-tamanhos-acai input[type="radio"]:checked + label {
-      background-color: #FFA726;
-      border-color: #D90429;
+      background-color: #FFD700;
+      border-color: #FF0000;
       font-weight: bold;
     }
 
@@ -4110,7 +4110,7 @@
             </div>
             <div style="margin-left: 10px;">
               <button onclick="removerPedido(${index})"
-                style="background-color: #FFB74D; color: #000; border: none; border-radius: 8px;
+                style="background-color: #FFEB3B; color: #000; border: none; border-radius: 8px;
                        padding: 8px 10px; font-size: 1em; cursor: pointer;">
                 🗑️
               </button>


### PR DESCRIPTION
## Summary
- use brighter yellow and red tones across site
- enlarge header font size for readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68851d1ba0a883328ef31e5d2e2a7c21